### PR TITLE
using existing state counter to act as an interrupt during the draw routine

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -160,8 +160,17 @@ static int draw_webp(uint8_t *buf, size_t len) {
   int delay = 0;
   TickType_t drawStartTick = xTaskGetTickCount();
 
+  int counter = _state->counter;
+
   // Draw each frame, and sleep for the delay
   for (int j = 0; j < animation.frame_count; j++) {
+
+    if (counter != _state->counter) {
+      // they've changed something- bomb out and start the process of loading in the next anim
+      delay = 0;
+      break;
+    }
+
     uint8_t *pix;
     int timestamp;
     WebPAnimDecoderGetNext(decoder, &pix, &timestamp);


### PR DESCRIPTION
problem looks to me like it's the draw loop- once data is loaded and buffered transferred the draw routine is called to play the anim through regardless of its length.  So I've used the state counter and added a check on each frame of draw to see if it should exit early if an animation has outstayed its welcome!

Needs a bit more testing, but makes logical sense to me? 